### PR TITLE
Update eos.tmLanguage.json

### DIFF
--- a/syntaxes/eos.tmLanguage.json
+++ b/syntaxes/eos.tmLanguage.json
@@ -40,7 +40,7 @@
 		"disable": {
 			"patterns": [{
 				"name": "invalid.illegal.eos",
-				"match": "\\s*no(?! shutdown)"
+				"match": "^\\s*no(?! shutdown)"
 			},
 			{
 				"name": "invalid.illegal.eos",


### PR DESCRIPTION
Ensure that we only match on "no" at start of any line, so that we don't match on commands such as "ip igmp snooping report-flooding"